### PR TITLE
6. Display all users when opening the chat

### DIFF
--- a/app/Controllers/Ws/ChatController.js
+++ b/app/Controllers/Ws/ChatController.js
@@ -17,7 +17,8 @@ class ChatController {
     users.add(user);
     this.socket.user = user;
     this.socket.emit('joined', {
-      user
+      user,
+      users: Array.from(users)
     });
   }
 

--- a/public/client.js
+++ b/public/client.js
@@ -18,6 +18,21 @@ ws.on('open', () => {
     joinedAs.textContent = user;
   });
 
+  chat.on('joined', ({ users }) => {
+    let ul = document.createElement('ul');
+    ul.id = 'joined-users';
+
+    users.forEach((user) => {
+      let li = document.createElement('li');
+      li.textContent = user;
+      ul.append(li);
+    });
+
+    let currentUl = document.querySelector('#joined-users');
+    currentUl.replaceWith(ul);
+  });
+
+
   chat.emit('userJoined');
 
   form.addEventListener('submit', (event) => {


### PR DESCRIPTION
After this, you should see a bug. That is, any existing tabs don't show new users who have joined the chat.

We could broadcast the entire user list to everyone in the chat whenever people join and leave, but that would send a lot more data. Instead, we can send the entire user list to the client when someone joins, and notify clients of the people who join and leave and let the clients update the UI. This way we don't need to constantly send the entire user list over the web socket.